### PR TITLE
Enable "Pan to Combatant" button in combat tracker

### DIFF
--- a/src/combat/_onCombatantControl.js
+++ b/src/combat/_onCombatantControl.js
@@ -42,5 +42,8 @@ export default async function _onCombatantControl(event) {
 
     // Actively ping the Combatant
     case 'pingCombatant': return this._onPingCombatant(c);
+
+    // Pan view to combatant (Non-GM only)
+    case 'panToCombatant': return this._onPanToCombatant(c);
   }
 }


### PR DESCRIPTION
The pan to combatant button, which is only shown for players, was
non-functional. This restores the functionality by re-enabling the
callback for the control.
