### PR TITLE
Adds a new critical damage roll option: Maximizing  highest damage die

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1275,6 +1275,7 @@
 		"critDoubleDiceQuantityAndMods": "Double dice quantity and double modifiers",
 		"critMaxDamage": "Maximize dice damage",
 		"critMaxDamagePlusRoll": "Maximize dice damage and roll a second set",
+		"critMaxHighestDie": "Maximize one of the highest damage die",
 		"deathSaveThreshold": "Death Save Threshold",
 		"diagonalRule": "Diagonal movement measurement",
 		"diagonalRuleNormal": "Equidistant (5/5/5)",

--- a/src/dice/damage/constructCritDamageRoll.js
+++ b/src/dice/damage/constructCritDamageRoll.js
@@ -6,6 +6,7 @@ import getBonusCritDamage from './getBonusCritDamage';
 import maxDamage from './maxDamage';
 import maxDamagePlusRoll from './maxDamagePlusRoll';
 import simplifyDiceTerms from '../simplifyDiceTerms';
+import maximizeHighestDie from './maxDamageOnHighestDie.js';
 
 const CRIT_CALCULATION_FUNCTION_MAP = {
 	doubleAllDamage,
@@ -14,6 +15,7 @@ const CRIT_CALCULATION_FUNCTION_MAP = {
 	doubleDiceQuantityAndMods,
 	maxDamage,
 	maxDamagePlusRoll,
+	maximizeHighestDie
 };
 
 export default async function constructCritDamageRoll(baseRoll, critBonus) {

--- a/src/dice/damage/maxDamageOnHighestDie.js
+++ b/src/dice/damage/maxDamageOnHighestDie.js
@@ -1,0 +1,45 @@
+export default async function maximizeHighestDie(baseRoll) {
+    const maxRoll = baseRoll.clone();
+
+    let highestDie = null;
+    let highestRollTermIndex = -1;
+
+    // Find the highest die in the roll
+    maxRoll.terms.forEach((term, idx) => {
+        if (term instanceof foundry.dice.terms.Die) {
+
+            if (!highestDie || term.faces > highestDie.faces) {
+                highestDie = term;
+                highestRollTermIndex = idx; // Track index of the highest die
+            }
+        }
+    });
+
+    // If no dice are present in the roll, return the original roll terms
+    if (!highestDie) {
+        return baseRoll.terms;
+    }
+
+    // If the highest die has more than 1 instance, reduce its count and add a maximized value to the end
+    if (highestDie.number > 1) {
+        // Reduce the number of dice in the original term
+        maxRoll.terms[highestRollTermIndex] = new foundry.dice.terms.Die({
+            number: highestDie.number - 1,
+            faces: highestDie.faces,
+            options: highestDie.options,
+        });
+
+        // Add the maximized value as a new term at the end
+        const maxValue = highestDie.faces;
+        maxRoll.terms.push(new foundry.dice.terms.OperatorTerm({ operator: '+' }));
+        maxRoll.terms.push(new foundry.dice.terms.NumericTerm({ number: maxValue })); // Add a static term for max value
+     } else {
+         // If there's only one die in the term, replace it with its maximized value
+         const maxValue = highestDie.faces;
+         maxRoll.terms[highestRollTermIndex] = new foundry.dice.terms.NumericTerm({ number: maxValue });
+     }
+
+    await maxRoll.evaluate();
+
+    return maxRoll.terms;
+}

--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -395,6 +395,7 @@ class A5eGameSettings extends TJSGameSettings {
 						doubleDiceQuantityAndMods: 'A5E.settings.critDoubleDiceQuantityAndMods',
 						maxDamage: 'A5E.settings.critMaxDamage',
 						maxDamagePlusRoll: 'A5E.settings.critMaxDamagePlusRoll',
+						maximizeHighestDie: 'A5E.settings.critMaxHighestDie',
 					},
 				},
 			},


### PR DESCRIPTION
I think, maximizing all damage dice or maximizing all damage dice and rolling a second set is quite the overkill. Some GMs like to house rule that one of the damage dice (the highest) is maxed while the others a rolled normally. Here are some examples:

- 1d4 + 2 -> 4 + 2
- 2d6 + 3 -> 1d6 + 6 + 3
- 1d4 + 2d8 + 1 -> 1d4 + 1d8 + 8 + 1 